### PR TITLE
Changed implementation to use the editors editable UI view

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ MyEditor.build = {
 ```
 
 ```css
-.ck-editor__is-empty .ck-content.ck-editor__editable::before,
 .ck-editor__is-empty.ck-content.ck-editor__editable::before {
 	content: 'The editor is empty';
 	position: absolute;
@@ -46,11 +45,13 @@ MyEditor.build = {
 }
 ```
 
-**_Whats with the weird CSS scope?_**
-
-Depending on the editor, the element used for content may not be the same as the one used when initialising the editor. Editors with toolbars will generate a new element structure. To cover all bases the scope is what it is -- where the `ck-editor__is-empty` class name is on the same element as the `ck-content` element or on a parent element.
+The empty class will be applied to the editable view for the editor, this may be different to a container element that particular editors may create and use.
 
 ## Changelog
+
+### v0.2.1 - 6 July 2018
+
+- Fix [alexeckermann/ckeditor5-emptyness#5](https://github.com/alexeckermann/ckeditor5-emptyness/issues/5): The plugin tested against a editor which performs differently to the non-test editor. This lead to an incorrect asumption about what view to use for the empty CSS class. As a result the plugin will now detect if it is integrating with an editor it supports, logs error and warning messages if needed. This also simplifies the CSS targeting to just the content editable element.
 
 ### v0.2.0 - 4 July 2018
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckeditor5-emptyness",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "How empty is your CKEditor instance? Adds observable isEmpty property to editors.",
   "keywords": [
     "ckeditor5",
@@ -8,13 +8,13 @@
   ],
   "dependencies": {
     "@ckeditor/ckeditor5-core": "^10.1.0",
-    "@ckeditor/ckeditor5-engine": "^10.1.0"
+    "@ckeditor/ckeditor5-engine": "^10.1.0",
+    "@ckeditor/ckeditor5-utils": "^10.1.0"
   },
   "devDependencies": {
     "@ckeditor/ckeditor5-editor-classic": "^10.0.1",
     "@ckeditor/ckeditor5-essentials": "^10.1.0",
-    "@ckeditor/ckeditor5-paragraph": "^10.1.0",
-    "@ckeditor/ckeditor5-utils": "^10.1.0",
+    "@ckeditor/ckeditor5-paragraph": "^10.0.1",
     "eslint": "^4.15.0",
     "eslint-config-ckeditor5": "^1.0.7",
     "husky": "^0.14.3",

--- a/src/emptyness.js
+++ b/src/emptyness.js
@@ -1,5 +1,6 @@
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 import Template from '@ckeditor/ckeditor5-ui/src/template';
+import log from '@ckeditor/ckeditor5-utils/src/log';
 
 export default class Emptyness extends Plugin {
 
@@ -10,13 +11,23 @@ export default class Emptyness extends Plugin {
 	init() {
 		const editor = this.editor;
 		const doc = editor.model.document;
-		const view = editor.ui.view;
+		const view = editor.ui.view.editable;
+		
+		if ( !view ) {
+			log.error( 'emptyness-view-not-found: expected editable view not found for this editor (expects editor.ui.view.editable to be defined)' );
+			return;
+		}
 
 		editor.set( 'isEmpty', !documentHasContent(doc) );
 
 		this.listenTo( doc, 'change:data', () => {
 			editor.set( 'isEmpty', !documentHasContent(doc) );
 		} );
+		
+		if ( view.isRendered === true ) {
+			log.warn( 'emptyness-view-is-rendered: can not extend the editor UI view after its been rendered, class name will be unavailable (see: template-extend-render)' );
+			return;
+		}
 		
 		const bind = Template.bind( editor, editor );
 		

--- a/tests/_utils/incompatibletesteditor.js
+++ b/tests/_utils/incompatibletesteditor.js
@@ -1,0 +1,26 @@
+import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import EditorUI from '@ckeditor/ckeditor5-core/src/editor/editorui';
+import IncompatibleTestEditorUIVIew from './incompatibletesteditoruiview';
+
+export default class IncompatibleTestEditor extends ClassicTestEditor {
+	/**
+	 * @inheritDoc
+	 */
+	constructor( element, config ) {
+		super( element, config );
+
+		if ( config._test.missingEditable === true ) {
+			// Intentially remove the editable property to trip up the plugin.
+			this.ui = new EditorUI( this, new IncompatibleTestEditorUIVIew( this.locale ) );
+			this.ui.view.editable = null;
+		}
+		
+		if ( config._test.renderView === true ) {
+			// Render the editable view so that its template can not be extended
+			this.ui.view.editable.render();
+		}
+		
+
+	}
+
+}

--- a/tests/_utils/incompatibletesteditoruiview.js
+++ b/tests/_utils/incompatibletesteditoruiview.js
@@ -1,0 +1,16 @@
+import BoxedEditorUIView from '@ckeditor/ckeditor5-ui/src/editorui/boxed/boxededitoruiview';
+import InlineEditableUIView from '@ckeditor/ckeditor5-ui/src/editableui/inline/inlineeditableuiview';
+
+export default class IncompatibleTestEditorUIView extends BoxedEditorUIView {
+	
+	render() {
+		
+		this.editable = new InlineEditableUIView( this.locale );
+		
+		super.render();
+		
+	}
+	
+	
+
+}

--- a/tests/emptyness.js
+++ b/tests/emptyness.js
@@ -4,10 +4,13 @@ import ModelText from '@ckeditor/ckeditor5-engine/src/model/text';
 import ModelRange from '@ckeditor/ckeditor5-engine/src/model/range';
 
 import ClassicTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/classictesteditor';
+import IncompatibleTestEditor from './_utils/incompatibletesteditor';
+
 import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 
 import testUtils from '@ckeditor/ckeditor5-core/tests/_utils/utils';
 import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
+import log from '@ckeditor/ckeditor5-utils/src/log';
 
 testUtils.createSinonSandbox();
 
@@ -32,79 +35,178 @@ describe( 'Emptyness', () => {
 		
 	};
 	
-	beforeEach( () => {
-		editorElement = document.createElement( 'div' );
-		document.body.appendChild( editorElement );
+	describe( 'with a compliant editor view structure', () => {
 		
-		return ClassicTestEditor
-			.create( editorElement, {
-				plugins: [ Emptyness, Paragraph ]
-			} )
-			.then( newEditor => {
-				editor = newEditor;
+		beforeEach( () => {
+			editorElement = document.createElement( 'div' );
+			document.body.appendChild( editorElement );
+		
+			return ClassicTestEditor
+				.create( editorElement, {
+					plugins: [ Emptyness, Paragraph ]
+				} )
+				.then( newEditor => {
+					editor = newEditor;
+				} );
+		} );
+	
+		afterEach( () => {
+			editorElement.remove();
+
+			return editor.destroy();
+		} );
+
+		it( 'should be loaded', () => {
+			expect( editor.plugins.get( Emptyness ) ).to.be.instanceOf( Emptyness );
+		} );
+	
+		describe( 'init()', () => {
+		
+			it( 'should set the isEmpty property', () => {
+				expect( editor.isEmpty ).to.be.true;
 			} );
+		
+		} );
+	
+		describe( 'isEmpty lifecycle', () => {
+		
+			it( 'should be false when content is inserted', () => {
+				const setSpy = testUtils.sinon.spy( editor, 'set' );
+			
+				insertContent();
+			
+				sinon.assert.calledWithExactly( setSpy, 'isEmpty', false );
+			} );
+		
+			it( 'should be true when all content is emptied', () => {
+				setData( editor.model, '<paragraph>test{}</paragraph>' );
+			
+				const setSpy = testUtils.sinon.spy( editor, 'set' );
+			
+				removeAllContent();
+			
+				sinon.assert.calledWithExactly( setSpy, 'isEmpty', true );
+			} );
+		
+		} );
+	
+		describe( 'view class lifecycle', () => {
+		
+			it( 'should not have the empty class content is inserted', () => {
+				let element = editor.ui.view.editable.editableElement;
+			
+				expect( element.classList.contains('ck-editor__is-empty') ).to.be.true;
+			
+				insertContent();
+			
+				expect( element.classList.contains('ck-editor__is-empty') ).to.be.false;
+			} );
+		
+			it( 'should add the empty class when all content is emptied', () => {
+				setData( editor.model, '<paragraph>test{}</paragraph>' );
+			
+				let element = editor.ui.view.editable.editableElement;
+			
+				expect( element.classList.contains('ck-editor__is-empty') ).to.be.false;
+			
+				removeAllContent();
+			
+				expect( element.classList.contains('ck-editor__is-empty') ).to.be.true;
+			} );
+		
+		} );
+		
 	} );
 	
-	afterEach( () => {
-		editorElement.remove();
+	describe( 'with an incompatible editor', () => {
+		
+		let errorSpy;
+		
+		beforeEach( () => {
+			editorElement = document.createElement( 'div' );
+			document.body.appendChild( editorElement );
+			
+			errorSpy = testUtils.sinon.stub( log, 'error' );
+		
+			return IncompatibleTestEditor
+				.create( editorElement, {
+					plugins: [ Emptyness, Paragraph ],
+					_test: { missingEditable: true }
+				} )
+				.then( newEditor => {
+					editor = newEditor;
+				} );
+		} );
+	
+		afterEach( () => {
+			editorElement.remove();
 
-		return editor.destroy();
-	} );
+			return editor.destroy();
+		} );
 
-	it( 'should be loaded', () => {
-		expect( editor.plugins.get( Emptyness ) ).to.be.instanceOf( Emptyness );
-	} );
-	
-	describe( 'init()', () => {
-		
-		it( 'should set the isEmpty property', () => {
-			expect( editor.isEmpty ).to.be.true;
+		it( 'should be loaded', () => {
+			expect( editor.plugins.get( Emptyness ) ).to.be.instanceOf( Emptyness );
 		} );
-		
-	} );
 	
-	describe( 'isEmpty lifecycle', () => {
+		describe( 'init()', () => {
 		
-		it( 'should be false when content is inserted', () => {
-			const setSpy = testUtils.sinon.spy( editor, 'set' );
+			it( 'should not set the isEmpty property', () => {
+				expect( editor.isEmpty ).to.be.undefined;
+			} );
 			
-			insertContent();
-			
-			sinon.assert.calledWithExactly( setSpy, 'isEmpty', false );
-		} );
+			it( 'should log an error', () => {
+				sinon.assert.calledOnce( errorSpy );
+				sinon.assert.calledWithMatch( errorSpy, /^emptyness-view-not-found/ );
+			} );
 		
-		it( 'should be true when all content is emptied', () => {
-			setData( editor.model, '<paragraph>test{}</paragraph>' );
-			
-			const setSpy = testUtils.sinon.spy( editor, 'set' );
-			
-			removeAllContent();
-			
-			sinon.assert.calledWithExactly( setSpy, 'isEmpty', true );
 		} );
 		
 	} );
 	
-	describe( 'view class lifecycle', () => {
+	describe( 'with an editor view that is rendered', () => {
 		
-		it( 'should not have the empty class content is inserted', () => {
-			expect( editor.ui.view.element.classList.contains('ck-editor__is-empty') ).to.be.true;
+		let warnSpy;
+		
+		beforeEach( () => {
+			editorElement = document.createElement( 'div' );
+			document.body.appendChild( editorElement );
 			
-			insertContent();
-			
-			expect( editor.ui.view.element.classList.contains('ck-editor__is-empty') ).to.be.false;
+			warnSpy = testUtils.sinon.stub( log, 'warn' );
+		
+			return IncompatibleTestEditor
+				.create( editorElement, {
+					plugins: [ Emptyness, Paragraph ],
+					_test: { renderView: true }
+				} )
+				.then( newEditor => {
+					editor = newEditor;
+				} );
 		} );
+	
+		afterEach( () => {
+			editorElement.remove();
+
+			return editor.destroy();
+		} );
+
+		it( 'should be loaded', () => {
+			expect( editor.plugins.get( Emptyness ) ).to.be.instanceOf( Emptyness );
+		} );
+	
+		describe( 'init()', () => {
 		
-		it( 'should add the empty class when all content is emptied', () => {
-			setData( editor.model, '<paragraph>test{}</paragraph>' );
+			it( 'should set the isEmpty property', () => {
+				expect( editor.isEmpty ).not.to.be.undefined;
+			} );
 			
-			expect( editor.ui.view.element.classList.contains('ck-editor__is-empty') ).to.be.false;
-			
-			removeAllContent();
-			
-			expect( editor.ui.view.element.classList.contains('ck-editor__is-empty') ).to.be.true;
+			it( 'should log a warning', () => {
+				sinon.assert.calledOnce( warnSpy );
+				sinon.assert.calledWithMatch( warnSpy, /^emptyness-view-is-rendered/ );
+			} );
+		
 		} );
 		
 	} );
+	
 
 } );

--- a/tests/manual/emptyness.html
+++ b/tests/manual/emptyness.html
@@ -1,6 +1,5 @@
 <head>
 	<style>
-		.ck-editor__is-empty .ck-content.ck-editor__editable::before,
 		.ck-editor__is-empty.ck-content.ck-editor__editable::before {
 			content: 'The editor is empty';
 			position: absolute;


### PR DESCRIPTION
Previous implementation was based on an incorrect assumption in the `ClassicTestEditor` that does not match the non-test `ClassicEditor` interface (see: [ckeditor/ckeditor5-core#137](https://github.com/ckeditor/ckeditor5-core/issues/137)). The plugin will also test its assumptions about views and extending templates to prevent raising unnecessary errors and breaking end-user usability.

- **Note:** CSS selectors are now only added to the editable view. This makes the CSS scope simpler.
- No impact on previous implementations, full support of provided CKEditor editor classes.